### PR TITLE
Follow Python 3.13 dependencies

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,5 @@
 bot:
-  inspection: update-grayskull
+  inspection: hint-grayskull
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - google-api-core-grpc
     - google-auth >=2.14.1,<3.0.0dev,!=2.24.0,!=2.25.0
     # use Python 3.13 version constraint to keep package noarch
-    - proto-plus >=1.22.3,<2.0.0dev
+    - proto-plus >=1.25.0,<2.0.0dev
     - protobuf >=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
 
 test:


### PR DESCRIPTION
The upstream dependency on proto-plus is stricter for Python 3.13 and above. In the past, we have chosen to adopt a single strictest dependency on google-cloud-* packages to keep the packages "noarch". This commit re-implements that policy which was accidentally reverted in

https://github.com/googleapis/google-cloud-python/blob/google-cloud-billing-budgets-v1.15.1/packages/google-cloud-billing-budgets/setup.py#L49

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
